### PR TITLE
Updated the atsign.dev links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -49,13 +49,13 @@ IP address.
 
 ## Developer resources
 
-[atsign.dev](https://atsign.dev) holds all of our Docs, Showcases, Community
-links and details of the atDev Program.
+[docs.atsign.com](https://docs.atsign.com/) holds all of our Docs, Showcases, Community
+links, and details of the atDev Program.
 
 The site itself is open source, in the
 [atsign.dev repo](https://github.com/atsign-foundation/atsign.dev).
 
-[atsign.dev](https://atsign.dev) is built on [Hugo](https://gohugo.io/)
+[docs.atsign.com](https://docs.atsign.com/) is built on [Hugo](https://gohugo.io/)
 using [at_docsy](https://github.com/atsign-foundation/at_docsy), our fork of
 the [Docsy theme](https://www.docsy.dev/).
 


### PR DESCRIPTION
On this page, I Updated the readme page with the new developers portal link - docs.atsign.com. 

Also, instead of docs.atsign.com in the squared brackets, do we want to use 'developer portal' instead?

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I made edits to the Readme.nd page

**- How I did it**
I hyperlinked the new devsite link. However, I am not sure if we want to refer to it as 'devsite', developer portal, or docs.atsign.com.

**- How to verify it**
Check the edits.

**- Description for the changelog**
Updated  the hyperlinked devsite links.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->