### PR TITLE
Updated the hyperlink for a broken link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 <img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
 
 Welcome to The Atsign Foundation Github Organization, home to the open source
-repos for [The atPlatform](https://atsign.dev/docs/).
+repos for [The atPlatform](https://docs.atsign.com).
 
 ## Our most important repos
 


### PR DESCRIPTION
Updated the link on line 6 of this readme page.

It was redirecting to a 404 page

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated a broken link 

**- How I did it**
I changed the link from https://docs.atsign.com/docs/  to https://docs.atsign.com/


**- How to verify it**
This is the error page: 
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/33583060/188669154-e5bdb29f-a6e0-45fe-afee-3e824bd48a2b.png">


**- Description for the changelog**
Updated broken link.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->