### PR TITLE
fix: Use absolute path for .github URLs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -53,8 +53,8 @@ IP address.
 * Visit [pub.dev](https://pub.dev/publishers/atsign.org/packages) to find all of our Dart & Flutter packages.
 * Our [YouTube channel](https://www.youtube.com/c/AtsignCo) contains tutorials and demos for learning about the atPlatform.
 * Join our [discord community](https://discord.atsign.com/)
-* [How we use GitHub at Atsign](../atGitHub.md)
-* [at_mono - a synthetic monorepo across many of our key repos](../at_mono.md)
+* [How we use GitHub at Atsign](https://github.com/atsign-foundation/.github/blob/trunk/atGitHub.md)
+* [at_mono - a synthetic monorepo across many of our key repos](https://github.com/atsign-foundation/.github/blob/trunk/at_mono.md)
 
 ## We are proud to sponsor
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

From https://github.com/atsign-foundation the use of relative URLs was causing a 404, hence the replacement to absolute URLs.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: Use exact path for .github URLs
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->