### PR TITLE
docs: Add page for OSSF Scorecards

### DIFF
--- a/docs/OpenSSF_scorecards.md
+++ b/docs/OpenSSF_scorecards.md
@@ -1,8 +1,10 @@
 # OpenSSF Scorecards
 
-Following the example set by [Dart and Flutter](https://opensource.googleblog.com/2022/06/Dart-and-Flutter-enable-Allstar-and-Security-Scorecards.html)
-we've implemented [OpenSSF Scorecards](https://securityscorecards.dev/) on
-key repos:
+Following the example set by
+[Dart and Flutter](https://opensource.googleblog.com/2022/06/Dart-and-Flutter-enable-Allstar-and-Security-Scorecards.html)
+we've implemented
+[Open Source Security Foundation Scorecards](https://securityscorecards.dev/)
+on key repos:
 
 
 | Repo | OpenSSF scorecard |

--- a/docs/OpenSSF_scorecards.md
+++ b/docs/OpenSSF_scorecards.md
@@ -1,0 +1,22 @@
+# OpenSSF Scorecards
+
+Following the example set by [Dart and Flutter](https://opensource.googleblog.com/2022/06/Dart-and-Flutter-enable-Allstar-and-Security-Scorecards.html)
+we've implemented [OpenSSF Scorecards](https://securityscorecards.dev/) on
+key repos:
+
+
+| Repo | OpenSSF scorecard |
+|---|---|
+| [at_app](https://github.com/atsign-foundation/at_app) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) |  
+| [at_client_sdk](https://github.com/atsign-foundation/at_client_sdk) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) | 
+| [at_demos](https://github.com/atsign-foundation/at_demos) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) | 
+| [at_java](https://github.com/atsign-foundation/at_java) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java) | 
+| [at_libraries](https://github.com/atsign-foundation/at_libraries) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_libraries/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_libraries) | 
+| [at_protocol](https://github.com/atsign-foundation/at_protocol) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol) | 
+| [at_server](https://github.com/atsign-foundation/at_server) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_server) | 
+| [at_tools](https://github.com/atsign-foundation/at_tools) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_tools/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_tools) | 
+| [at_widgets](https://github.com/atsign-foundation/at_widgets) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_widgets/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_widgets) | 
+| [dess](https://github.com/atsign-foundation/dess) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/dess/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/dess) | 
+| [docs.atsign.com](https://github.com/atsign-foundation/docs.atsign.com) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com) | 
+| [mwc_demo](https://github.com/atsign-foundation/mwc_demo) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo) | 
+| [sshnoports](https://github.com/atsign-foundation/sshnoports) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports) | 

--- a/profile/README.md
+++ b/profile/README.md
@@ -62,6 +62,11 @@ IP address.
 * [How we use GitHub at Atsign](https://github.com/atsign-foundation/.github/blob/trunk/docs/atGitHub.md)
 * [at_mono - a synthetic monorepo across many of our key repos](https://github.com/atsign-foundation/.github/blob/trunk/docs/at_mono.md)
 
+## Supply chain security
+
+The repos featured on this profile each have
+[OpenSSF Scorecards](../docs/OpenSSF_scorecards.md).
+
 ## We are proud to sponsor
 
 ![EFF](https://atsign.com/wp-content/uploads/2021/10/2021-org-member-badge.png.webp)


### PR DESCRIPTION
Saves us from having to refer to #41 all the time

**- What I did**

Added a page with a table of scorecards in alphabetical order by repo
Linked to that page from the profile README

**- Description for the changelog**

docs: Add page for OSSF Scorecards