### PR TITLE
fix: Correct scorecard links

### DIFF
--- a/docs/OpenSSF_scorecards.md
+++ b/docs/OpenSSF_scorecards.md
@@ -9,9 +9,9 @@ on key repos:
 
 | Repo | OpenSSF scorecard |
 |---|---|
-| [at_app](https://github.com/atsign-foundation/at_app) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_app/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) |  
+| [at_app](https://github.com/atsign-foundation/at_app) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_app/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_app) |  
 | [at_client_sdk](https://github.com/atsign-foundation/at_client_sdk) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) | 
-| [at_demos](https://github.com/atsign-foundation/at_demos) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_demos/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_client_sdk) | 
+| [at_demos](https://github.com/atsign-foundation/at_demos) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_demos/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_demos) | 
 | [at_java](https://github.com/atsign-foundation/at_java) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_java) | 
 | [at_libraries](https://github.com/atsign-foundation/at_libraries) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_libraries/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_libraries) | 
 | [at_protocol](https://github.com/atsign-foundation/at_protocol) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol) | 


### PR DESCRIPTION
Spotted that it wasn't just the badges that were wrong. Links need to be fixed too.

**- Description for the changelog**

fix: Correct scorecard links