### PR TITLE
docs: Add Alpha SDK Scorecards

### DIFF
--- a/docs/OpenSSF_scorecards.md
+++ b/docs/OpenSSF_scorecards.md
@@ -22,3 +22,12 @@ on key repos:
 | [docs.atsign.com](https://github.com/atsign-foundation/docs.atsign.com) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com) | 
 | [mwc_demo](https://github.com/atsign-foundation/mwc_demo) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo) | 
 | [sshnoports](https://github.com/atsign-foundation/sshnoports) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports) | 
+
+These repos are for alpha SDKs, and will take a little while to mature:
+
+| Repo | OpenSSF scorecard |
+|---|---|
+| [at_c](https://github.com/atsign-foundation/at_c) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_c/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_c) |  
+| [at_esp32](https://github.com/atsign-foundation/at_esp32) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_esp32/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_esp32) |  
+| [at_python](https://github.com/atsign-foundation/at_python) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_python/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_python) |  
+| [at_rust](https://github.com/atsign-foundation/at_rust) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_rust/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_rust) |  


### PR DESCRIPTION
For https://github.com/atsign-foundation/operations/issues/43

**- What I did**

Added Alpha SDKs to scorecards list

**- How I did it**

A separate section, as these repos are immature

**- How to verify it**

See [preview](https://github.com/atsign-foundation/.github/blob/cpswan-sdk-scorecards/docs/OpenSSF_scorecards.md)

**- Description for the changelog**

docs: Add Alpha SDK Scorecards