### PR TITLE
docs: Remove org README title

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,9 +1,7 @@
-# The Atsign Foundation
-
 <a href="https://atsign.com#gh-light-mode-only">
-   <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="Atsign Logo"></a>
+   <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a>
 <a href="https://atsign.com#gh-dark-mode-only">
-   <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.png#gh-dark-mode-only" alt="Atsign Logo"></a>
+   <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.png#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 [![Gitbook Docs](https://img.shields.io/badge/Docs-white?style=for-the-badge&logo=gitbook)](https://docs.atsign.com)
 [![Discord Community](https://img.shields.io/badge/Discord-white?style=for-the-badge&logo=discord)](https://discord.atsign.com)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed the title from the org profile README, since there is already a title on the GitHub site:

![CleanShot 2023-08-25 at 16 19 16@2x](https://github.com/atsign-foundation/.github/assets/33691921/8fe163ea-9f02-44e5-8a3c-ea6ee51475aa)

Updated the logo alt to contain the title contents.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
docs: Remove org README title
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->