### PR TITLE
docs: Remove mwc_demo from scorecard list

### DIFF
--- a/docs/OpenSSF_scorecards.md
+++ b/docs/OpenSSF_scorecards.md
@@ -20,7 +20,6 @@ on key repos:
 | [at_widgets](https://github.com/atsign-foundation/at_widgets) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_widgets/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_widgets) | 
 | [dess](https://github.com/atsign-foundation/dess) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/dess/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/dess) | 
 | [docs.atsign.com](https://github.com/atsign-foundation/docs.atsign.com) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/docs.atsign.com) | 
-| [mwc_demo](https://github.com/atsign-foundation/mwc_demo) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/mwc_demo) | 
 | [sshnoports](https://github.com/atsign-foundation/sshnoports) | [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/sshnoports) | 
 
 These repos are for alpha SDKs, and will take a little while to mature:


### PR DESCRIPTION
Since we moved mwc_demo to at_demos (and archived the original repo) it doesn't need to have its own entry in scorecards

**- What I did**

Removed scorecard row for mwc_demo

**- How to verify it**

Visible in rich diff

**- Description for the changelog**

docs: Remove mwc_demo from scorecard list