### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -63,7 +63,7 @@ repos for [Atsign's technology](https://docs.atsign.com/).
 <!-- pyml disable-num-lines 12 md012,md013,md033-->
 
 <div>
-   <img height=120px src="https://atsign.com/wp-content/uploads/2024/07/2024_member_org_badge.png" alt="EFF Org Member">
+   <img height=120px src="https://atsign.com/wp-content/uploads/2025/01/2025-OrgMember.png.webp" alt="EFF Org Member">
    <img height=120px src="https://atsign.com/wp-content/uploads/2022/10/GEC-graphics-01.png" alt="Global Encryption Coalition">
    <img height=120px src="https://atsign.com/wp-content/uploads/2022/10/IoTSF-Corporate-Membership-Badge.png" alt="IoT Security Foundation">
    <img height=120px src="https://atsign.com/wp-content/uploads/2023/02/ioXt_logo2020_July-1.png" alt="ioXt">


### PR DESCRIPTION
swapped out the 2024 EFF badge for the 2025 one

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Updated the EFF badge to be current for 2025

**- How I did it** Updated the image link to the new image 

**- How to verify it** checked preview mode, new image is rendering 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: Updated the link for the EFF badge to be current for 2025
-->
