### PR TITLE
ci: Workflow to bump pylock.toml

### DIFF
--- a/.github/workflows/bump-pylock.yml
+++ b/.github/workflows/bump-pylock.yml
@@ -1,0 +1,40 @@
+name: Bump pylock.toml
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+
+permissions:
+  pull-requests: write
+  
+jobs:
+  bump_pylock:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout this repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.MY_GITHUB_TOKEN }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
+      with:
+        working-directory: tools
+        activate-environment: true
+
+    - name: Bump patch version and lock file
+      working-directory: tools
+      run: |
+        git config --global user.name 'library-action[bot]'
+        git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        v=$(uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version)
+        uvx --from bump2version bumpversion --allow-dirty --current-version "$v" "patch" pyproject.toml
+        uv lock
+        uv export -o pylock.toml
+        git add pyproject.toml pylock.toml
+        git commit -m "build(deps): Bump pyproject.toml version and pylock.toml"
+        git push


### PR DESCRIPTION
Dependabot currently doesn't bump the pylock.toml when it updates pyproject.toml

**- What I did**

Added a workflow to bump the patch version in pyproject.toml then export a new pylock.toml

**- How I did it**

Based on:

https://github.com/atsign-foundation/at_python/blob/trunk/.github/workflows/bump-pyproject.yml

and

https://stackoverflow.com/questions/79176155/how-to-bump-python-package-version-using-uv

**- How to verify it**

Will need to wait for another bump to pymarkdownlnt

**- Description for the changelog**

ci: Workflow to bump pylock.toml
