### PR TITLE
ci: Use new uv version --bump command

### DIFF
--- a/.github/workflows/bump-pylock.yml
+++ b/.github/workflows/bump-pylock.yml
@@ -31,8 +31,7 @@ jobs:
       run: |
         git config --global user.name 'library-action[bot]'
         git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-        v=$(uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version)
-        uvx --from bump2version bumpversion --allow-dirty --current-version "$v" "patch" pyproject.toml
+        uv version --bump patch
         uv lock
         uv export -o pylock.toml
         git add pyproject.toml pylock.toml


### PR DESCRIPTION
`uv version --bump` just got released in uv 0.7.0, which greatly simplifies applying a version bump to pyproject.toml

**- What I did**

Replaced uvx commands with `uv version --bump`

**- How to verify it**

Will run on next Dependabot bump to pymarkdownlnt

**- Description for the changelog**

ci: Use new uv version --bump command