### PR TITLE
docs: Note that issues will be left open

### DIFF
--- a/docs/atGitHub.md
+++ b/docs/atGitHub.md
@@ -198,6 +198,12 @@ Where it's not obvious how much effort is expected we make use of
 team to determine an estimate. Issues are exported from GitHub Projects
 using the [Dump Cards](https://github.com/atsign-company/dump_cards) scripts.
 
+### Issues will be left open
+
+We do not use a bot to auto close issues after a given time. If they're not
+scheduled into a sprint then they will simply stay open. Time isn't
+allocated for grooming old issues.
+
 ## Labels
 
 The [labels](https://github.com/atsign-company/labels) repo is used to


### PR DESCRIPTION
@cconstab asked in an arch call what we should do about issues that have been left open, and it was agreed to have a note added here.

**- What I did**

Added a sub-section to note that issues will be left open

**- How to verify it**

:eyes: on rich diff

**- Description for the changelog**

docs: Note that issues will be left open
